### PR TITLE
rocket: update to be compatible with 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,5 @@ description = "throw any error inside rocket's route"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rocket = {git="https://github.com/SergioBenitez/Rocket"}
-anyhow = "1.0.40"
-
-[dev-dependencies]
+rocket = "0.5.1"
+anyhow = "1.0.100"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ where
     }
 }
 
-impl<'r> Responder<'r, 'static> for Error {
+impl<'r> Responder<'r, 'r> for Error {
     fn respond_to(self, request: &Request<'_>) -> response::Result<'static> {
         response::Debug(self.0).respond_to(request)
     }


### PR DESCRIPTION
The current GitHub and crates.io versions of rocket_anyhow are incompatible with Rocket 0.5.1 and modern Rust due to having a dependency tree littered with crates which were dependent on old nightly features.

This patch updates the dependencies and makes a minor source change to be compatible with Rocket's current API. Upon merging of this patch, the crate on crates.io should be updated to allow other crates pushed to crates.io to utilize these changes.